### PR TITLE
refactor(markdown): カスタムコンポーネントの型を厳密に定義

### DIFF
--- a/src/components/markdown/markdown-content.tsx
+++ b/src/components/markdown/markdown-content.tsx
@@ -1,8 +1,8 @@
-import { type CustomComponents, markdownProcessor } from "@/server";
+import { type MarkdownComponents, markdownProcessor } from "@/server";
 
 interface MarkdownContentProps {
   content: string;
-  components?: CustomComponents;
+  components?: MarkdownComponents;
 }
 
 /**

--- a/src/server/markdown/processor.ts
+++ b/src/server/markdown/processor.ts
@@ -9,13 +9,13 @@ import remarkParseFrontmatter from "remark-parse-frontmatter";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";
 
-import type { CustomComponents } from "./types";
+import type { MarkdownComponents } from "./types";
 
 /**
  * Markdown プロセッサ
  * @param components - コンポーネントマッピング
  */
-export function markdownProcessor(components: CustomComponents = {}) {
+export function markdownProcessor(components: MarkdownComponents = {}) {
   return unified()
     .use(remarkParse)
     .use(remarkFrontmatter)

--- a/src/server/markdown/types.ts
+++ b/src/server/markdown/types.ts
@@ -8,7 +8,7 @@ export type { Article };
  * HTMLとコンポーネントのマッピング
  * @todo 必要なHTMLタグを追加する
  */
-export interface CustomComponents {
+export interface MarkdownComponents {
   h1?: ComponentType<ComponentProps<"h1">>;
   h2?: ComponentType<ComponentProps<"h2">>;
   p?: ComponentType<ComponentProps<"p">>;


### PR DESCRIPTION
- カスタムコンポーネントの型を厳密に定義
- 上記型をリネーム `CustomComponents` -> `MarkdownComponents`