### PR TITLE
test(api-notify-newcomer): ライブラリ依存を改善

### DIFF
--- a/test/api/notify/newcomer.test.ts
+++ b/test/api/notify/newcomer.test.ts
@@ -1,11 +1,13 @@
-import { testApiHandler } from "next-test-api-route-handler";
+import { NextRequest } from "next/server";
 import { describe, expect, it } from "vitest";
 
-import * as appHandler from "@/app/api/v1/notify/newcomer/route";
+import { POST } from "@/app/api/v1/notify/newcomer/route";
 import type { Newcomer } from "@/models";
 import { createAPIResponse } from "@/server";
 
 describe("POST /api/v1/notify/newcomer", () => {
+  const REQUEST_URL = "http://localhost:3000/api/v1/notify/newcomer";
+
   it("正常なリクエストを処理できる", async () => {
     const validBody: Newcomer = {
       name: "foobar",
@@ -15,20 +17,15 @@ describe("POST /api/v1/notify/newcomer", () => {
       csrfToken: "csrf-token",
     };
 
-    await testApiHandler({
-      appHandler,
-      test: async ({ fetch }) => {
-        const response = await fetch({
-          method: "POST",
-          body: JSON.stringify(validBody),
-        });
-
-        expect(response.status).toBe(200);
-        expect(await response.json()).toMatchObject(
-          createAPIResponse(validBody)
-        );
-      },
+    const request = new NextRequest(REQUEST_URL, {
+      method: "POST",
+      body: JSON.stringify(validBody),
     });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject(createAPIResponse(validBody));
   });
 
   it("不正なメールアドレスの場合エラーを返す", async () => {
@@ -40,19 +37,16 @@ describe("POST /api/v1/notify/newcomer", () => {
       csrfToken: "csrf-token",
     };
 
-    await testApiHandler({
-      appHandler,
-      test: async ({ fetch }) => {
-        const response = await fetch({
-          method: "POST",
-          body: JSON.stringify(invalidBody),
-        });
-
-        expect(response.status).toBe(400);
-        const json = await response.json();
-        expect(json.error).toBeDefined();
-      },
+    const request = new NextRequest(REQUEST_URL, {
+      method: "POST",
+      body: JSON.stringify(invalidBody),
     });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBeDefined();
   });
 
   it("学籍番号が必要な場合にエラーを返す", async () => {
@@ -64,18 +58,15 @@ describe("POST /api/v1/notify/newcomer", () => {
       csrfToken: "csrf-token",
     };
 
-    await testApiHandler({
-      appHandler,
-      test: async ({ fetch }) => {
-        const response = await fetch({
-          method: "POST",
-          body: JSON.stringify(invalidBody),
-        });
-
-        expect(response.status).toBe(400);
-        const json = await response.json();
-        expect(json.error).toBeDefined();
-      },
+    const request = new NextRequest(REQUEST_URL, {
+      method: "POST",
+      body: JSON.stringify(invalidBody),
     });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toBeDefined();
   });
 });


### PR DESCRIPTION
[`next-test-api-route-handler`](https://www.npmjs.com/package/next-test-api-route-handler)が`next@14.4.20`以降では動かない。ライブラリ依存によるアップグレードできない問題を解消する。

## 関連
- #28 
